### PR TITLE
fix: unnecessary dirtying of ColoredGraphic

### DIFF
--- a/Assets/PurrUI/Runtime/Palette/ColoredGraphic.cs
+++ b/Assets/PurrUI/Runtime/Palette/ColoredGraphic.cs
@@ -238,24 +238,30 @@ namespace PurrNet.UI
         {
             if (colored == null)
             {
-                if (slotCount > 0 && _color.enabled)
+                if (slotCount > 0 && _color.enabled && _graphic.color != _current[0])
+                {
                     _graphic.color = _current[0];
 #if UNITY_EDITOR
-                if (!Application.isPlaying)
-                    UnityEditor.EditorUtility.SetDirty(_graphic);
+                    if (!Application.isPlaying)
+                        UnityEditor.EditorUtility.SetDirty(_graphic);
 #endif
+                }
                 return;
             }
 
             int count = Mathf.Min(_coloredInfos.Count, slotCount);
+            bool anyChanged = false;
             for (int i = 0; i < count; i++)
             {
-                if (_coloredInfos[i].enabled)
+                if (_coloredInfos[i].enabled && colored.GetColor(i) != _current[i])
+                {
                     colored.SetColor(i, _current[i]);
+                    anyChanged = true;
+                }
             }
 
 #if UNITY_EDITOR
-            if (!Application.isPlaying)
+            if (!Application.isPlaying && anyChanged)
                 UnityEditor.EditorUtility.SetDirty(_graphic);
 #endif
         }

--- a/Assets/PurrUI/Runtime/Palette/IColored.cs
+++ b/Assets/PurrUI/Runtime/Palette/IColored.cs
@@ -6,6 +6,8 @@ namespace PurrNet.UI
     {
         public string[] keys { get; }
 
+        public Color GetColor(int keyIndex);
+
         public void SetColor(int keyIndex, Color color);
     }
 }

--- a/Assets/PurrUI/Runtime/ProceduralUI/SignedDistanceFieldGraphic.cs
+++ b/Assets/PurrUI/Runtime/ProceduralUI/SignedDistanceFieldGraphic.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -528,6 +529,20 @@ namespace PurrNet.UI
         };
 
         public string[] keys => _keys;
+
+        public Color GetColor(int keyIndex)
+        {
+            return keyIndex switch
+            {
+                0 => graphicColor,
+                1 => gradientColor,
+                2 => outlineColor,
+                3 => shadowColor,
+                4 => embossHighlightColor,
+                5 => embossShadowColor,
+                _ => throw new ArgumentOutOfRangeException(nameof(keyIndex), keyIndex, $"Key index must be between 0 and {_keys.Length - 1}.")
+            };
+        }
 
         public void SetColor(int keyIndex, Color color)
         {


### PR DESCRIPTION
`ColoredGraphic` calls `UnityEditor.EditorUtility.SetDirty` every editor update, even when no color changes. This causes gameobject/scene containing a `ColoredGraphic` constantly being marked having changes.

Fix mark it dirty only if the color changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrUI/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788292712&installation_model_id=20441&pr_number=15&repository=PurrNet%2FPurrUI&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrUI%2Fpull%2F15&signature=d8e0c4e7c52b170e3055a115cc29a25daf5005380f90c76692db1f49158e15ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->